### PR TITLE
add arm64 support

### DIFF
--- a/dup2.go
+++ b/dup2.go
@@ -1,0 +1,11 @@
+// +build darwin dragonfly freebsd linux,!arm64 netbsd openbsd
+
+package panicwrap
+
+import (
+	"syscall"
+)
+
+func dup2(oldfd, newfd int) error {
+	return syscall.Dup2(oldfd, newfd)
+}

--- a/dup3.go
+++ b/dup3.go
@@ -1,0 +1,11 @@
+// +build linux,arm64
+
+package panicwrap
+
+import (
+	"syscall"
+)
+
+func dup2(oldfd, newfd int) error {
+	return syscall.Dup3(oldfd, newfd, 0)
+}

--- a/monitor.go
+++ b/monitor.go
@@ -6,7 +6,6 @@ import (
 	"github.com/bugsnag/osext"
 	"os"
 	"os/exec"
-	"syscall"
 )
 
 func monitor(c *WrapConfig) (int, error) {
@@ -54,7 +53,7 @@ func monitor(c *WrapConfig) (int, error) {
 		return -1, err
 	}
 
-	err = syscall.Dup2(int(write.Fd()), int(os.Stderr.Fd()))
+	err = dup2(int(write.Fd()), int(os.Stderr.Fd()))
 	if err != nil {
 		return -1, err
 	}


### PR DESCRIPTION
Because arm64 has no syscall.Dup2, use Dup3 instead.
