### PR TITLE
Do not return a -1 exit status after SIGINT

### DIFF
--- a/monitor.go
+++ b/monitor.go
@@ -3,7 +3,7 @@
 package panicwrap
 
 import (
-	"github.com/bugsnag/osext"
+	"github.com/kardianos/osext"
 	"os"
 	"os/exec"
 )

--- a/panicwrap.go
+++ b/panicwrap.go
@@ -12,7 +12,7 @@ package panicwrap
 import (
 	"bytes"
 	"errors"
-	"github.com/bugsnag/osext"
+	"github.com/kardianos/osext"
 	"io"
 	"os"
 	"os/exec"

--- a/panicwrap.go
+++ b/panicwrap.go
@@ -211,7 +211,7 @@ func wrap(c *WrapConfig) (int, error) {
 		}
 
 		exitStatus := 1
-		if status, ok := exitErr.Sys().(syscall.WaitStatus); ok {
+		if status, ok := exitErr.Sys().(syscall.WaitStatus); ok && status.Exited() {
 			exitStatus = status.ExitStatus()
 		}
 


### PR DESCRIPTION
`signal.ExitStatus()` can return -1, which makes the program re-execute without the panic wrapper.

See https://golang.org/src/syscall/syscall_linux.go?s=5681:5717#L214