### PR TITLE
Let child process handle SIGQUIT on Unix

### DIFF
--- a/monitor.go
+++ b/monitor.go
@@ -3,7 +3,7 @@
 package panicwrap
 
 import (
-	"github.com/bugsnag/osext"
+	"github.com/kardianos/osext"
 	"os"
 	"os/exec"
 )

--- a/panicwrap.go
+++ b/panicwrap.go
@@ -12,7 +12,7 @@ package panicwrap
 import (
 	"bytes"
 	"errors"
-	"github.com/bugsnag/osext"
+	"github.com/kardianos/osext"
 	"io"
 	"os"
 	"os/exec"

--- a/panicwrap.go
+++ b/panicwrap.go
@@ -211,7 +211,7 @@ func wrap(c *WrapConfig) (int, error) {
 		}
 
 		exitStatus := 1
-		if status, ok := exitErr.Sys().(syscall.WaitStatus); ok {
+		if status, ok := exitErr.Sys().(syscall.WaitStatus); ok && status.Exited() {
 			exitStatus = status.ExitStatus()
 		}
 

--- a/panicwrap.go
+++ b/panicwrap.go
@@ -191,7 +191,7 @@ func wrap(c *WrapConfig) (int, error) {
 	// Listen to signals and capture them forever. We allow the child
 	// process to handle them in some way.
 	sigCh := make(chan os.Signal)
-	signal.Notify(sigCh, os.Interrupt)
+	signal.Notify(sigCh, signalsToIgnore...)
 	go func() {
 		defer signal.Stop(sigCh)
 		for {

--- a/signal_notunix.go
+++ b/signal_notunix.go
@@ -1,0 +1,9 @@
+// +build plan9 windows
+
+package panicwrap
+
+import (
+	"os"
+)
+
+var signalsToIgnore = []os.Signal{os.Interrupt}

--- a/signal_unix.go
+++ b/signal_unix.go
@@ -1,0 +1,10 @@
+// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris
+
+package panicwrap
+
+import (
+	"os"
+	"syscall"
+)
+
+var signalsToIgnore = []os.Signal{os.Interrupt, syscall.SIGQUIT}


### PR DESCRIPTION
This allows devs to press <kbd>Ctrl</kbd> + <kbd>\\</kbd> on Unix to get a stack trace of the program.

The Go command does the same thing: https://github.com/golang/go/blob/0104a31b8fbcbe52728a08867b26415d282c35d2/src/cmd/go/signal_unix.go