### PR TITLE
Solaris builds also will not currently support monitor

### DIFF
--- a/monitor.go
+++ b/monitor.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build !windows !solaris
 
 package panicwrap
 


### PR DESCRIPTION
When building with solaris this error occurs:
`github.com/bugsnag/panicwrap/monitor.go:56: undefined: dup2`

Exclude solaris from using this file as well