### PR TITLE
Fix building for windows

### DIFF
--- a/monitor.go
+++ b/monitor.go
@@ -1,4 +1,4 @@
-// +build !windows !solaris
+// +build !windows,!solaris
 
 package panicwrap
 


### PR DESCRIPTION
The build tag space delimiter is an OR, where as a comma is an AND, which is the correct option in this case. I don't have solaris to verify this patch does break #4, but building to darwin/linux still work.