### PR TITLE
Support different panic headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## TBD
+
+### Features
+
+* Support capturing fatal errors from concurrent map writes, nil goroutines,
+  out of memory errors, stack exhaustion, and others which use a different panic
+  output format.
+
 ## 1.2.2 (2020-12-17)
 
 ### Bug fixes

--- a/panicwrap.go
+++ b/panicwrap.go
@@ -263,7 +263,7 @@ func trackPanic(r io.Reader, w io.Writer, dur time.Duration, result chan<- strin
 	panicBuf := new(bytes.Buffer)
 	panicHeaders := [][]byte{
 		[]byte("panic:"),
-		[]byte("fatal error: fault"),
+		[]byte("fatal error:"),
 	}
 	panicType := -1
 
@@ -272,7 +272,7 @@ func trackPanic(r io.Reader, w io.Writer, dur time.Duration, result chan<- strin
 		var buf []byte
 		var n int
 
-		if panicTimer == nil && panicBuf.Len() > 0 {
+		if panicType >= 0 && panicTimer == nil && panicBuf.Len() > 0 {
 			// We're not tracking a panic but the buffer length is
 			// greater than 0. We need to clear out that buffer, but
 			// look for another panic along the way.
@@ -322,6 +322,7 @@ func trackPanic(r io.Reader, w io.Writer, dur time.Duration, result chan<- strin
 			continue
 		}
 
+		// Check if the contents of buf starts with a header
 		panicType = -1
 		flushIdx := n
 		for i, header := range panicHeaders {

--- a/panicwrap.go
+++ b/panicwrap.go
@@ -261,7 +261,11 @@ func trackPanic(r io.Reader, w io.Writer, dur time.Duration, result chan<- strin
 
 	var panicTimer <-chan time.Time
 	panicBuf := new(bytes.Buffer)
-	panicHeader := []byte("panic:")
+	panicHeaders := [][]byte{
+		[]byte("panic:"),
+		[]byte("fatal error: fault"),
+	}
+	panicType := -1
 
 	tempBuf := make([]byte, 2048)
 	for {
@@ -274,7 +278,7 @@ func trackPanic(r io.Reader, w io.Writer, dur time.Duration, result chan<- strin
 			// look for another panic along the way.
 
 			// First, remove the previous panic header so we don't loop
-			w.Write(panicBuf.Next(len(panicHeader)))
+			w.Write(panicBuf.Next(len(panicHeaders[panicType])))
 
 			// Next, assume that this is our new buffer to inspect
 			n = panicBuf.Len()
@@ -318,22 +322,27 @@ func trackPanic(r io.Reader, w io.Writer, dur time.Duration, result chan<- strin
 			continue
 		}
 
+		panicType = -1
 		flushIdx := n
-		idx := bytes.Index(buf[0:n], panicHeader)
-		if idx >= 0 {
-			flushIdx = idx
+		for i, header := range panicHeaders {
+			idx := bytes.Index(buf[0:n], header)
+			if idx >= 0 {
+				panicType = i
+				flushIdx = idx
+				break
+			}
 		}
 
 		// Flush to stderr what isn't a panic
 		w.Write(buf[0:flushIdx])
 
-		if idx < 0 {
+		if panicType == -1 {
 			// Not a panic so just continue along
 			continue
 		}
 
 		// We have a panic header. Write we assume is a panic os far.
-		panicBuf.Write(buf[idx:n])
+		panicBuf.Write(buf[flushIdx:n])
 		panicTimer = time.After(dur)
 	}
 }


### PR DESCRIPTION
## Goal

Capture errors beginning with "fatal error". This includes concurrent map read/write errors, out of memory errors, and calling nil goroutines.

## Changeset

* Update the go process output parser to detect "fatal error"

### Linked issues

* https://github.com/bugsnag/bugsnag-go/pull/153 (required before merging)