### PR TITLE
build: remove osext dependency

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -1,0 +1,9 @@
+// +build go1.8
+
+package panicwrap
+
+import "os"
+
+func Executable() (string, error) {
+	return os.Executable()
+}

--- a/exec_old.go
+++ b/exec_old.go
@@ -1,0 +1,9 @@
+// +build !go1.8
+
+package panicwrap
+
+import "github.com/kardianos/osext"
+
+func Executable() (string, error) {
+	return osext.Executable()
+}

--- a/monitor.go
+++ b/monitor.go
@@ -3,7 +3,6 @@
 package panicwrap
 
 import (
-	"github.com/kardianos/osext"
 	"os"
 	"os/exec"
 )
@@ -29,7 +28,7 @@ func monitor(c *WrapConfig) (int, error) {
 		os.Exit(0)
 	}
 
-	exePath, err := osext.Executable()
+	exePath, err := Executable()
 	if err != nil {
 		return -1, err
 	}

--- a/panicwrap.go
+++ b/panicwrap.go
@@ -12,7 +12,6 @@ package panicwrap
 import (
 	"bytes"
 	"errors"
-	"github.com/kardianos/osext"
 	"io"
 	"os"
 	"os/exec"
@@ -143,7 +142,7 @@ func wrap(c *WrapConfig) (int, error) {
 	}
 
 	// Get the path to our current executable
-	exePath, err := osext.Executable()
+	exePath, err := Executable()
 	if err != nil {
 		return -1, err
 	}


### PR DESCRIPTION
Only installs a dependency when needed (go1.7). On newer versions, the package is now third-party dependency free.