### PR TITLE
fix: support arm64-based macOS builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## TBD
+
+### Bug fixes
+
+* Add build support from arm64-based macOS by updating build settings for
+  `dup2()`
+
 ## 1.3.1 (2021-01-12)
 
 This release removes the dependency on [osext](https://github.com/kardianos/osext)

--- a/dup2.go
+++ b/dup2.go
@@ -1,4 +1,4 @@
-// +build !arm64,!windows
+// +build !windows
 
 package panicwrap
 


### PR DESCRIPTION
## Goal

Supporting compilation and crash detection on ARM-based Macs

## Changeset

* Removed a check in `dup2.go` to allow compilation of the file on arm-64 builds

## Tests

* Tested manually on an M1 Mac to confirm the issue and the fix on go1.16.2

### Linked issues

* Fixes #18 