### PR TITLE
Prevent the build of dup2.go on Linux aarch64

### DIFF
--- a/dup2.go
+++ b/dup2.go
@@ -1,4 +1,5 @@
 // +build !windows
+// +build linux,!arm64
 
 package panicwrap
 


### PR DESCRIPTION
The dup2 syscall does not exist on Linux aarch64.

Fix #20.