### PR TITLE
fix: support building on riscv64 linux

### DIFF
--- a/dup2.go
+++ b/dup2.go
@@ -1,4 +1,4 @@
-// +build linux,!arm64 !linux,!windows
+// +build linux,!arm64,!riscv64 !linux,!windows
 
 package panicwrap
 

--- a/dup3.go
+++ b/dup3.go
@@ -1,4 +1,4 @@
-//+build linux,arm64
+//+build linux,arm64 linux,riscv64
 
 package panicwrap
 


### PR DESCRIPTION
Like all modern architectures there is no dup2 on riscv.